### PR TITLE
modified code added for slideshow

### DIFF
--- a/assets/component-slideshow.css
+++ b/assets/component-slideshow.css
@@ -28,7 +28,7 @@ slideshow-component .slideshow.banner {
 }
 
 @media screen and (min-width: 750px) {
-  .slideshow--placeholder.banner--adapt_image {
+  .slideshow--placeholder.banner--adapt_image .slideshow__slide  {
     height: 56rem;
   }
 }

--- a/assets/section--tab-collection.css
+++ b/assets/section--tab-collection.css
@@ -1,0 +1,41 @@
+/* .tags-tabs {
+  overflow-x: hidden;
+} */
+.tabs-menu {
+  margin-bottom: 15px;
+}
+.tab-button {
+  padding: 10px 20px;
+  margin: 5px;
+  cursor: pointer;
+  background: #f1f1f1;
+  border: 1px solid #ddd;
+  display: inline-block;
+}
+.tab-button.active {
+  background: #000;
+  color: #fff;
+}
+.tab-content {
+  display: none;
+}
+.tab-content.active {
+  display: block;
+}
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 15px;
+  position: relative;
+}
+.product-card {
+  border: 1px solid #ddd;
+  padding: 10px;
+}
+.ctm_tbcols .productgrid--item {
+  height: auto;
+  width: 100%;
+}
+.image-full {
+  max-width: 100%;
+}

--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -85,16 +85,22 @@
     flex-direction: row;
   }
 
-  .banner--small:not(.banner--adapt) {
-    min-height: 42rem;
+  .banner--small:not(.banner--adapt),
+  .banner--small:not(.banner--adapt) .slideshow__slide,
+  .banner--small:not(.banner--adapt) .slideshow__text-wrapper {
+    min-height: 36rem;
   }
 
-  .banner--medium:not(.banner--adapt) {
-    min-height: 56rem;
+  .banner--medium:not(.banner--adapt),
+  .banner--medium:not(.banner--adapt) .slideshow__slide,
+  .banner--medium:not(.banner--adapt) .slideshow__text-wrapper {
+    min-height: 52rem;
   }
 
-  .banner--large:not(.banner--adapt) {
-    min-height: 72rem;
+  .banner--large:not(.banner--adapt), 
+  .banner--large:not(.banner--adapt) .slideshow__slide,
+  .banner--large:not(.banner--adapt) .slideshow__text-wrapper {
+    min-height: 68rem;
   }
 
   .banner__content.banner__content--top-left {
@@ -218,6 +224,10 @@
   height: auto;
 }
 
+.banner:not(.banner--mobile-bottom):not(.email-signup-banner) .banner__box {
+  background: transparent;
+}
+
 @media screen and (max-width: 749px) {
   .banner--mobile-bottom .banner__media,
   .banner--stacked:not(.banner--mobile-bottom) .banner__media {
@@ -228,9 +238,6 @@
     height: auto;
   }
 
-  .banner:not(.banner--mobile-bottom):not(.email-signup-banner) .banner__box {
-    background: transparent;
-  }
 
   .banner:not(.banner--mobile-bottom) .banner__box {
     border: none;
@@ -383,16 +390,27 @@
   }
 }
 
-.banner::after,
 .banner__media::after {
   content: '';
   position: absolute;
   top: 0;
+  left: 0;
   background: #000000;
   opacity: 0;
   z-index: 1;
   width: 100%;
   height: 100%;
+}
+
+.ovlshw_ltr .banner__media::after {
+  opacity:1;
+  background: linear-gradient(90deg, #0000 62.91%, #000 91.37%);
+  transform: scaleX(-1);
+}
+
+.ovlshw_rtl .banner__media::after {
+  opacity:1;
+  background: linear-gradient(90deg, #0000 62.91%, #000 91.37%);
 }
 
 .banner__box > * + .banner__text {
@@ -416,6 +434,12 @@
 @media screen and (max-width: 749px) {
   .banner--stacked .banner__box {
     width: 100%;
+  }
+
+   .ovlshw_fullscreen .banner__media::after,
+  .ovlshw_ltr .banner__media::after,
+  .ovlshw_rtl .banner__media::after {
+     opacity:0;
   }
 }
 
@@ -480,6 +504,9 @@
   .banner:not(.slideshow) .inline-richtext a:hover,
   .banner:not(.slideshow) .rte a:hover {
     color: currentColor;
+  }
+  .banner__box {
+    height: 100%;
   }
 }
 

--- a/sections/ctm-tab-collection.liquid
+++ b/sections/ctm-tab-collection.liquid
@@ -1,0 +1,506 @@
+<!-- sections/ctm-tab-collection -->
+{{ 'section-main-product.css' | asset_url | stylesheet_tag }}
+{{ 'section-featured-product.css' | asset_url | stylesheet_tag }}
+{{ 'component-accordion.css' | asset_url | stylesheet_tag }}
+{{ 'component-price.css' | asset_url | stylesheet_tag }}
+{{ 'component-deferred-media.css' | asset_url | stylesheet_tag }}
+{{ 'component-rating.css' | asset_url | stylesheet_tag }}
+{{ 'component-volume-pricing.css' | asset_url | stylesheet_tag }}
+{{ 'component-product-variant-picker.css' | asset_url | stylesheet_tag }}
+{{ 'component-swatch.css' | asset_url | stylesheet_tag }}
+{{ 'component-swatch-input.css' | asset_url | stylesheet_tag }}
+    
+{{ 'component-card.css' | asset_url | stylesheet_tag }}
+{{ 'component-price.css' | asset_url | stylesheet_tag }}
+
+{{ 'component-slider.css' | asset_url | stylesheet_tag }}
+{{ 'template-collection.css' | asset_url | stylesheet_tag }}
+
+{{ 'section--tab-collection.css' | asset_url | stylesheet_tag }}
+
+{%- unless section.settings.quick_add == 'none' -%}
+  {{ 'quick-add.css' | asset_url | stylesheet_tag }}
+  <script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
+{%- endunless -%}
+
+{%- if section.settings.quick_add == 'standard' -%}
+  <script src="{{ 'quick-add.js' | asset_url }}" defer="defer"></script>
+{%- endif -%}
+
+{%- style -%}
+  .section-{{ section.id }}-padding {
+    padding-top: {{ section.settings.re_padding_top }}px;
+    padding-bottom: {{ section.settings.re_padding_bottom }}px;
+  }
+
+  @media (min-width: 750px) {
+    .section-{{ section.id }}-padding {
+      padding-top: {{ section.settings.padding_top }}px;
+      padding-bottom: {{ section.settings.padding_bottom }}px;
+    }
+  }
+
+   @media (min-width: 1401px) {
+  .section-{{ section.id }}-padding .tg_slides_five .swiper-button-prev,
+  .section-{{ section.id }}-padding .tg_slides_five .swiper-button-next{
+    display: none;
+  }
+  }
+{%- endstyle -%}
+
+<div
+  class="ctm_tbcols ctm-swiper-arrow section-{{ section.id }}-padding {{ section.settings.extra_class }}"
+  data-featured-collection
+>
+  <div class="page-width">
+    {% if section.settings.section_heading != blank %}
+      <div class="section-heading">
+        <h2 class="tab-title">{{ section.settings.section_heading }}</h2>
+      </div>
+    {% endif %}
+
+    {% if section.settings.section_subheading != blank %}
+      <div class="section-subheading">
+        {{ section.settings.section_subheading }}
+      </div>
+    {% endif %}
+
+    <div class="tags-tabs" data-content>
+      <div class="tabs-menu_main">
+        <div class="tabs-menu">
+          {% for block in section.blocks %}
+            {% if block.type == 'category' %}
+              <button class="tab-button {% if forloop.first %}active{% endif %}" data-tag="{{ block.id }}">
+                {% if block.settings.title != blank %}
+                  {{ block.settings.title }}
+                {% else %}
+                  {{ collection.title }}
+                {% endif %}
+              </button>
+            {% endif %}
+          {% endfor %}
+        </div>
+      </div>
+
+      <div class="tabs-content tabbed_contents">
+        {% for block in section.blocks %}
+          {% if block.type == 'category' %}
+            <div
+              class="tab-content tab-content_{{ block.id }} {% if forloop.first %}active{% endif %}"
+              data-tag="{{ block.id }}"
+            >
+              {% assign collection = collections[block.settings.collection] %}
+              <div class="product-grid{% if collection.products.size < 6 or block.settings.product_limit < 6 %} tg_slides_five {% endif %}">
+                {% if block.settings.col_pdp == true %}
+                  <div class="tags_slider_{{ block.id }} swiper productgrid--item{% if collection.products.size < 6 or block.settings.product_limit < 6 %} tg_slider_five {% endif %}">
+                    <div class="swiper-wrapper product-grid-list">
+                      {% if collection != blank %}
+                        {% if collection.products.size > 0 %}
+                          {% for product in collection.products limit: block.settings.product_limit %}
+                            <div class="swiper-slide grid__item tg_product_card">
+                              {% render 'card-product',
+                                media_aspect_ratio: 'square',
+                                image_shape: 'default',
+                                card_product: product,
+                                lazy_load: true,
+                                show_secondary_image: true,
+                                show_vendor: true,
+                                show_rating: true,
+                                section_id: section.id,
+                                quick_add: section.settings.quick_add
+                              %}
+                            </div>
+                          {% endfor %}
+                        {% else %}
+                          <p>
+                            We are currently adding products for the "
+                            {%- if block.settings.collection != blank -%}
+                              {{- block.settings.title -}}
+                            {%- else -%}
+                              {{- collection.title -}}
+                            {%- endif -%}
+                            " category
+                          </p>
+                        {% endif %}
+                      {% else %}
+                        <p class="no_product_found">
+                          No products found for "
+                          {{- block.settings.title -}}
+                          "
+                        </p>
+                      {% endif %}
+                    </div>
+                  </div>
+                  <div class="swiper-button-prev">{{- 'icon-caret-left.svg' | inline_asset_content -}}</div>
+                  <div class="swiper-button-next">{{- 'icon-caret-left.svg' | inline_asset_content -}}</div>
+                {% else %}
+                  {% assign product = all_products[block.settings.singleproduct] %}
+                  <product-info
+                    class="single_tab_prods "
+                    data-section="{{ block.id }}"
+                    data-product-id="{{ product.id }}"
+                    data-update-url="false"
+                    data-url="{{ product.url }}"
+                    {% if block.settings.image_zoom == 'hover' %}
+                      data-zoom-on-hover
+                    {% endif %}
+                  >
+                    <div class="single_prods_main featured-product product product--{{ section.settings.media_size }} grid grid--1-col product--{{ section.settings.media_position }}{% if product.media.size > 0 or section.settings.product == blank %}grid--2-col-tablet{% else %}product--no-media{% endif %}">
+                      {% render 'ctm-single-product', product: product, block: block %}
+                    </div>
+                  </product-info>
+                {% endif %}
+              </div>
+
+              {% if collection.products.size > 0 and section.settings.hide_shopall == false %}
+                <div class="ctm_tbcols_shop">
+                  <a
+                    {% if collection.url %}
+                      href="{{ collection.url }}"
+                    {% else %}
+                      role="link" aria-disabled="true"
+                    {% endif %}
+                    {%- if block.settings.collection != blank -%}
+                      title="{{- block.settings.title | strip_html -}}"
+                    {%- else -%}
+                      title="{{- collection.title | strip_html -}}"
+                    {%- endif -%}
+                    class="button button-primary"
+                  >
+                    <span> Shop {{ block.settings.title -}}</span>
+                  </a>
+                </div>
+              {% endif %}
+            </div>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const tabs = document.querySelectorAll('.section-{{ section.id }}-padding .tab-button');
+    const contents = document.querySelectorAll('.section-{{ section.id }}-padding .tab-content');
+    const tabsMenu = document.querySelector('.section-{{ section.id }}-padding .tabs-menu');
+
+    function centerActiveTab(tab) {
+      if (tabsMenu && tab) {
+        const tabRect = tab.getBoundingClientRect();
+        const containerRect = tabsMenu.getBoundingClientRect();
+        const scrollLeft = tabsMenu.scrollLeft;
+        const offset = tabRect.left - containerRect.left + (tabRect.width / 2) - (containerRect.width / 2);
+        tabsMenu.scrollTo({
+          left: scrollLeft + offset,
+          behavior: 'smooth'
+        });
+      }
+    }
+
+    tabs.forEach(tab => {
+      tab.addEventListener('click', () => {
+        let targetTag = tab.getAttribute('data-tag');
+
+        tabs.forEach(t => t.classList.remove('active'));
+        contents.forEach(c => c.classList.remove('active'));
+
+        tab.classList.add('active');
+        document.querySelector('.section-{{ section.id }}-padding .tab-content[data-tag="' + targetTag + '"]').classList.add('active');
+
+        centerActiveTab(tab);
+      });
+    });
+
+    // Center the first active tab on load
+    const firstActive = document.querySelector('.section-{{ section.id }}-padding .tab-button.active');
+    if (firstActive) {
+      centerActiveTab(firstActive);
+    }
+
+  });
+
+  {% for block in section.blocks %}
+          {% if block.type == 'category' %}
+            {% if block.settings.col_pdp == true %}
+      new Swiper('.tags_slider_{{ block.id }}', {
+          loop: false,
+          slidesPerView: 6,
+          navigation: {
+          nextEl: '.tab-content_{{ block.id }} .swiper-button-next',
+          prevEl: '.tab-content_{{ block.id }} .swiper-button-prev',
+      },
+          paginationClickable: true,
+          spaceBetween: 20,
+          autoplay: false,
+          watchOverflow: true,
+          breakpoints: {
+              1920: {
+                  slidesPerView: 6,
+                  spaceBetween: 20
+              },
+              1400: {
+                  slidesPerView: 5,
+                  spaceBetween: 20
+              },
+              1200: {
+                  slidesPerView: 4,
+                  spaceBetween: 20
+              },
+              769: {
+                  slidesPerView: 3,
+                  spaceBetween: 20
+              },
+              500: {
+                  slidesPerView: 2,
+                  spaceBetween: 20
+              },
+              200: {
+                  slidesPerView: 1,
+                  spaceBetween: 20
+              }
+          }
+      });
+  {% endif %}
+  {% endif %}
+  {% endfor %}
+</script>
+
+{% schema %}
+{
+  "name": "Custom Tab Collection",
+  "settings": [
+    {
+      "type": "inline_richtext",
+      "id": "section_heading",
+      "label": "Heading"
+    },
+    {
+      "type": "richtext",
+      "id": "section_subheading",
+      "label": "Content"
+    },
+    {
+      "type": "checkbox",
+      "id": "hide_shopall",
+      "label": "Hide shop all collection button",
+      "default": false
+    },
+    {
+      "type": "header",
+      "content": "t:sections.featured-product.settings.header.content",
+      "info": "Media options are workn only in single product"
+    },
+    {
+      "type": "select",
+      "id": "media_size",
+      "options": [
+        {
+          "value": "small",
+          "label": "t:sections.main-product.settings.media_size.options__1.label"
+        },
+        {
+          "value": "medium",
+          "label": "t:sections.main-product.settings.media_size.options__2.label"
+        },
+        {
+          "value": "large",
+          "label": "t:sections.main-product.settings.media_size.options__3.label"
+        }
+      ],
+      "default": "medium",
+      "label": "t:sections.main-product.settings.media_size.label"
+    },
+    {
+      "type": "checkbox",
+      "id": "constrain_to_viewport",
+      "default": true,
+      "label": "t:sections.main-product.settings.constrain_to_viewport.label"
+    },
+    {
+      "type": "select",
+      "id": "media_fit",
+      "options": [
+        {
+          "value": "contain",
+          "label": "t:sections.main-product.settings.media_fit.options__1.label"
+        },
+        {
+          "value": "cover",
+          "label": "t:sections.main-product.settings.media_fit.options__2.label"
+        }
+      ],
+      "default": "contain",
+      "label": "t:sections.main-product.settings.media_fit.label"
+    },
+    {
+      "type": "select",
+      "id": "media_position",
+      "options": [
+        {
+          "value": "left",
+          "label": "t:sections.featured-product.settings.media_position.options__1.label"
+        },
+        {
+          "value": "right",
+          "label": "t:sections.featured-product.settings.media_position.options__2.label"
+        }
+      ],
+      "default": "left",
+      "label": "t:sections.featured-product.settings.media_position.label"
+    },
+    {
+      "type": "select",
+      "id": "image_zoom",
+      "options": [
+        {
+          "value": "lightbox",
+          "label": "t:sections.main-product.settings.image_zoom.options__1.label"
+        },
+        {
+          "value": "hover",
+          "label": "t:sections.main-product.settings.image_zoom.options__2.label"
+        },
+        {
+          "value": "none",
+          "label": "t:sections.main-product.settings.image_zoom.options__3.label"
+        }
+      ],
+      "default": "lightbox",
+      "label": "t:sections.main-product.settings.image_zoom.label"
+    },
+    {
+      "type": "checkbox",
+      "id": "hide_variants",
+      "default": false,
+      "label": "t:sections.main-product.settings.hide_variants.label"
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_video_looping",
+      "default": false,
+      "label": "t:sections.featured-product.settings.enable_video_looping.label"
+    },
+    {
+      "type": "select",
+      "id": "quick_add",
+      "default": "none",
+      "label": "t:sections.main-collection-product-grid.settings.quick_add.label",
+      "options": [
+        {
+          "value": "none",
+          "label": "t:sections.main-collection-product-grid.settings.quick_add.options.option_1"
+        },
+        {
+          "value": "standard",
+          "label": "t:sections.main-collection-product-grid.settings.quick_add.options.option_2"
+        }
+      ]
+    },
+    {
+      "type": "header",
+      "content": "Spacing"
+    },
+    {
+      "type": "range",
+      "id": "padding_top",
+      "min": 0,
+      "max": 100,
+      "step": 2,
+      "unit": "px",
+      "label": "Top spacing",
+      "default": 0
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom",
+      "min": 0,
+      "max": 100,
+      "step": 2,
+      "unit": "px",
+      "label": "Bottom Spacing",
+      "default": 0
+    },
+    {
+      "type": "range",
+      "id": "re_padding_top",
+      "min": 0,
+      "max": 100,
+      "step": 2,
+      "unit": "px",
+      "label": "Responsive Top spacing",
+      "default": 0
+    },
+    {
+      "type": "range",
+      "id": "re_padding_bottom",
+      "min": 0,
+      "max": 100,
+      "step": 2,
+      "unit": "px",
+      "label": "Responsive Bottom Spacing",
+      "default": 0
+    },
+    {
+      "type": "header",
+      "content": "Options for Dev"
+    },
+    {
+      "type": "text",
+      "id": "extra_class",
+      "label": "Extra Class"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "category",
+      "name": "Collection Block",
+      "settings": [
+        {
+          "type": "text",
+          "id": "title",
+          "label": "Tab Title"
+        },
+        {
+          "type": "product",
+          "id": "singleproduct",
+          "label": "Select a product"
+        },
+        {
+          "type": "checkbox",
+          "id": "show_dynamic_checkout",
+          "default": true,
+          "label": "t:sections.featured-product.blocks.buy_buttons.settings.show_dynamic_checkout.label",
+          "info": "t:sections.featured-product.blocks.buy_buttons.settings.show_dynamic_checkout.info"
+        },
+        {
+          "type": "checkbox",
+          "id": "col_pdp",
+          "label": "Display collection products",
+          "info": "Selecting this checkbox will display the collection’s products instead of single products. To show collections, this checkbox must be checked.",
+          "default": true
+        },
+        {
+          "type": "collection",
+          "id": "collection",
+          "label": "Select Collection"
+        },
+        {
+          "type": "range",
+          "id": "product_limit",
+          "label": "Products per tab",
+          "min": 1,
+          "max": 20,
+          "default": 8,
+          "visible_if": "{{ block.settings.col_pdp == true }}"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Custom Tab Collection"
+    }
+  ]
+}
+{% endschema %}

--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -2,8 +2,13 @@
 {{ 'component-slider.css' | asset_url | stylesheet_tag }}
 {{ 'component-slideshow.css' | asset_url | stylesheet_tag }}
 
-{%- if section.settings.slide_height == 'adapt_image' and section.blocks.first.settings.image != blank -%}
-  {%- style -%}
+<link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css">
+
+{%- style -%}
+  .section-{{ section.id }} {
+    position: relative;
+  }
+  {%- if section.settings.slide_height == 'adapt_image' and section.blocks.first.settings.image != blank -%}
     @media screen and (max-width: 749px) {
       #Slider-{{ section.id }}::before,
       #Slider-{{ section.id }} .media::before,
@@ -22,244 +27,162 @@
         display: block;
       }
     }
-  {%- endstyle -%}
-{%- endif -%}
-
-<slideshow-component
-  class="slider-mobile-gutter{% if section.settings.layout == 'grid' %} page-width{% endif %}{% if section.settings.show_text_below %} mobile-text-below{% endif %}"
-  role="region"
-  aria-roledescription="{{ 'sections.slideshow.carousel' | t }}"
-  aria-label="{{ section.settings.accessibility_info | escape }}"
->
-  {%- if section.settings.auto_rotate and section.blocks.size > 1 -%}
-    <div class="slideshow__controls slideshow__controls--top slider-buttons{% if section.settings.show_text_below %} slideshow__controls--border-radius-mobile{% endif %}">
-      <button
-        type="button"
-        class="slider-button slider-button--prev"
-        name="previous"
-        aria-label="{{ 'sections.slideshow.previous_slideshow' | t }}"
-        aria-controls="Slider-{{ section.id }}"
-      >
-        <span class="svg-wrapper">
-          {{- 'icon-caret.svg' | inline_asset_content -}}
-        </span>
-      </button>
-      <div class="slider-counter slider-counter--{{ section.settings.slider_visual }}{% if section.settings.slider_visual == 'counter' or section.settings.slider_visual == 'numbers' %} caption{% endif %}">
-        {%- if section.settings.slider_visual == 'counter' -%}
-          <span class="slider-counter--current">1</span>
-          <span aria-hidden="true"> / </span>
-          <span class="visually-hidden">{{ 'general.slider.of' | t }}</span>
-          <span class="slider-counter--total">{{ section.blocks.size }}</span>
-        {%- else -%}
-          <div class="slideshow__control-wrapper">
-            {%- for block in section.blocks -%}
-              <button
-                class="slider-counter__link slider-counter__link--{{ section.settings.slider_visual }} link"
-                aria-label="{{ 'sections.slideshow.load_slide' | t }} {{ forloop.index }} {{ 'general.slider.of' | t }} {{ forloop.length }}"
-                aria-controls="Slider-{{ section.id }}"
-              >
-                {%- if section.settings.slider_visual == 'numbers' -%}
-                  {{ forloop.index -}}
-                {%- else -%}
-                  <span class="dot"></span>
-                {%- endif -%}
-              </button>
-            {%- endfor -%}
-          </div>
-        {%- endif -%}
-      </div>
-      <button
-        type="button"
-        class="slider-button slider-button--next"
-        name="next"
-        aria-label="{{ 'sections.slideshow.next_slideshow' | t }}"
-        aria-controls="Slider-{{ section.id }}"
-      >
-        <span class="svg-wrapper">
-          {{- 'icon-caret.svg' | inline_asset_content -}}
-        </span>
-      </button>
-
-      {%- if section.settings.auto_rotate -%}
-        <button
-          type="button"
-          class="slideshow__autoplay slider-button{% if section.settings.auto_rotate == false %} slideshow__autoplay--paused{% endif %}"
-          aria-label="{{ 'sections.slideshow.pause_slideshow' | t }}"
-        >
-          <span class="svg-wrapper">
-            {{- 'icon-pause.svg' | inline_asset_content -}}
-          </span>
-          <span class="svg-wrapper">
-            {{- 'icon-play.svg' | inline_asset_content -}}
-          </span>
-        </button>
-      {%- endif -%}
-    </div>
   {%- endif -%}
+{%- endstyle -%}
 
+<div class="section-{{ section.id }} {% if section.settings.layout == 'grid' %} page-width{% endif %}{% if section.settings.show_text_below %} mobile-text-below{% endif %}">
   <div
-    class="slideshow banner banner--{{ section.settings.slide_height }} grid grid--1-col slider slider--everywhere{% if section.settings.show_text_below %} banner--mobile-bottom{% endif %}{% if section.blocks.first.settings.image == blank %} slideshow--placeholder{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}"
+    class="slideshow banner banner--{{ section.settings.slide_height }} swiper{% if section.settings.show_text_below %} banner--mobile-bottom{% endif %}{% if section.blocks.first.settings.image == blank %} slideshow--placeholder{% endif %}"
     id="Slider-{{ section.id }}"
-    aria-live="polite"
-    aria-atomic="true"
-    data-autoplay="{{ section.settings.auto_rotate }}"
-    data-speed="{{ section.settings.change_slides_speed }}"
   >
-    {%- for block in section.blocks -%}
-      <style>
-        #Slide-{{ section.id }}-{{ forloop.index }} .banner__media::after {
-          opacity: {{ block.settings.image_overlay_opacity | divided_by: 100.0 }};
-        }
-      </style>
-      <div
-        class="slideshow__slide grid__item grid--1-col slider__slide"
-        id="Slide-{{ section.id }}-{{ forloop.index }}"
-        {{ block.shopify_attributes }}
-        role="group"
-        aria-roledescription="{{ 'sections.slideshow.slide' | t }}"
-        aria-label="{{ forloop.index }} {{ 'general.slider.of' | t }} {{ forloop.length }}"
-        tabindex="-1"
-      >
-        <div class="slideshow__media banner__media media{% if block.settings.image == blank %} placeholder{% endif %}{% if section.settings.image_behavior != 'none' %} animate--{{ section.settings.image_behavior }}{% endif %}">
-          {%- if block.settings.image -%}
-            {%- liquid
-              assign height = block.settings.image.width | divided_by: block.settings.image.aspect_ratio | round
-              if section.settings.image_behavior == 'ambient'
-                assign sizes = '120vw'
-                assign widths = '450, 660, 900, 1320, 1800, 2136, 2400, 3600, 7680'
-              else
-                assign sizes = '100vw'
-                assign widths = '375, 550, 750, 1100, 1500, 1780, 2000, 3000, 3840'
-              endif
-              assign fetch_priority = 'auto'
-              if section.index == 1
-                assign fetch_priority = 'high'
-              endif
-            -%}
-            {%- if forloop.first %}
-              {{
-                block.settings.image
-                | image_url: width: 3840
-                | image_tag: height: height, sizes: sizes, widths: widths, fetchpriority: fetch_priority
-              }}
-            {%- else -%}
-              {{
-                block.settings.image
-                | image_url: width: 3840
-                | image_tag: loading: 'lazy', height: height, sizes: sizes, widths: widths
-              }}
-            {%- endif -%}
-          {%- else -%}
-            {%- assign placeholder_slide = forloop.index | modulo: 2 -%}
-            {%- if placeholder_slide == 1 -%}
-              {{ 'hero-apparel-2' | placeholder_svg_tag: 'placeholder-svg' }}
-            {%- else -%}
-              {{ 'hero-apparel-1' | placeholder_svg_tag: 'placeholder-svg' }}
-            {%- endif -%}
-          {%- endif -%}
-        </div>
-        <div class="slideshow__text-wrapper banner__content banner__content--{{ block.settings.box_align }} page-width{% if block.settings.show_text_box == false %} banner--desktop-transparent{% endif %}{% if settings.animations_reveal_on_scroll and forloop.index == 1 %} scroll-trigger animate--slide-in{% endif %}">
-          <div class="slideshow__text banner__box content-container content-container--full-width-mobile color-{{ block.settings.color_scheme }} gradient slideshow__text--{{ block.settings.text_alignment }} slideshow__text-mobile--{{ block.settings.text_alignment_mobile }}">
-            {%- if block.settings.heading != blank -%}
-              <h2 class="banner__heading inline-richtext {{ block.settings.heading_size }}">
-                {{ block.settings.heading }}
-              </h2>
-            {%- endif -%}
-            {%- if block.settings.subheading != blank -%}
-              <div class="banner__text rte">
-                <p>{{ block.settings.subheading }}</p>
-              </div>
-            {%- endif -%}
-            {%- if block.settings.button_label != blank -%}
-              <div class="banner__buttons">
-                <a
-                  {% if block.settings.link %}
-                    href="{{ block.settings.link }}"
-                  {% else %}
-                    role="link" aria-disabled="true"
-                  {% endif %}
-                  class="button {% if block.settings.button_style_secondary %}button--secondary{% else %}button--primary{% endif %}"
-                >
-                  {{- block.settings.button_label | escape -}}
-                </a>
-              </div>
-            {%- endif -%}
-          </div>
-        </div>
-      </div>
-    {%- endfor -%}
-  </div>
-
-  {%- if section.blocks.size > 1 and section.settings.auto_rotate == false -%}
-    <div class="slideshow__controls slider-buttons{% if section.settings.show_text_below %} slideshow__controls--border-radius-mobile{% endif %}">
-      <button
-        type="button"
-        class="slider-button slider-button--prev"
-        name="previous"
-        aria-label="{{ 'sections.slideshow.previous_slideshow' | t }}"
-        aria-controls="Slider-{{ section.id }}"
-      >
-        <span class="svg-wrapper">
-          {{- 'icon-caret.svg' | inline_asset_content -}}
-        </span>
-      </button>
-      <div class="slider-counter slider-counter--{{ section.settings.slider_visual }}{% if section.settings.slider_visual == 'counter' or section.settings.slider_visual == 'numbers' %} caption{% endif %}">
-        {%- if section.settings.slider_visual == 'counter' -%}
-          <span class="slider-counter--current">1</span>
-          <span aria-hidden="true"> / </span>
-          <span class="visually-hidden">{{ 'general.slider.of' | t }}</span>
-          <span class="slider-counter--total">{{ section.blocks.size }}</span>
-        {%- else -%}
-          <div class="slideshow__control-wrapper">
-            {%- for block in section.blocks -%}
-              <button
-                class="slider-counter__link slider-counter__link--{{ section.settings.slider_visual }} link"
-                aria-label="{{ 'sections.slideshow.load_slide' | t }} {{ forloop.index }} {{ 'general.slider.of' | t }} {{ forloop.length }}"
-                aria-controls="Slider-{{ section.id }}"
-              >
-                {%- if section.settings.slider_visual == 'numbers' -%}
-                  {{ forloop.index -}}
-                {%- else -%}
-                  <span class="dot"></span>
-                {%- endif -%}
-              </button>
-            {%- endfor -%}
-          </div>
-        {%- endif -%}
-      </div>
-      <button
-        type="button"
-        class="slider-button slider-button--next"
-        name="next"
-        aria-label="{{ 'sections.slideshow.next_slideshow' | t }}"
-        aria-controls="Slider-{{ section.id }}"
-      >
-        <span class="svg-wrapper">
-          {{- 'icon-caret.svg' | inline_asset_content -}}
-        </span>
-      </button>
-
-      {%- if section.settings.auto_rotate -%}
-        <button
-          type="button"
-          class="slideshow__autoplay slider-button{% if section.settings.auto_rotate == false %} slideshow__autoplay--paused{% endif %}"
-          aria-label="{{ 'sections.slideshow.pause_slideshow' | t }}"
+    <div class="swiper-wrapper">
+      {%- for block in section.blocks -%}
+        <div class="swiper-slide">
+        <div
+          class="slideshow__slide slider__slide ovlshw_{{block.settings.opacity_effect}}"
+          id="Slide-{{ section.id }}-{{ forloop.index }}"
+          {{ block.shopify_attributes }}
+          role="group"
+          aria-roledescription="{{ 'sections.slideshow.slide' | t }}"
+          aria-label="{{ forloop.index }} {{ 'general.slider.of' | t }} {{ forloop.length }}"
+          tabindex="-1"
         >
-          <span class="svg-wrapper">
-            {{- 'icon-pause.svg' | inline_asset_content -}}
-          </span>
-          <span class="svg-wrapper">
-            {{- 'icon-play.svg' | inline_asset_content -}}
-          </span>
-        </button>
-      {%- endif -%}
+          <div class="slideshow__media banner__media media{% if block.settings.image == blank %} placeholder{% endif %}">
+            {%- if block.settings.main_bg or block.settings.main_video_bg -%}
+              {% if forloop.first %}
+                {% render 'ctm-media',
+                  class: 'ctm_ssow_top',
+                  video: block.settings.main_video_bg,
+                  mob_video: block.settings.mob_video_bg,
+                  image: block.settings.main_bg,
+                  mob_image: block.settings.main_mobile_bg,
+                  enable_looping: block.settings.enable_video_looping,
+                  heading: block.settings.heading,
+                  loading: 'eager',
+                  fetchpriority: 'high'
+                %}
+              {% else %}
+                {% render 'ctm-media',
+                  class: 'ctm_ssow_top',
+                  video: block.settings.main_video_bg,
+                  mob_video: block.settings.mob_video_bg,
+                  image: block.settings.main_bg,
+                  mob_image: block.settings.main_mobile_bg,
+                  enable_looping: block.settings.enable_video_looping,
+                  heading: block.settings.heading,
+                  loading: 'lazy',
+                  fetchpriority: 'auto'
+                %}
+              {% endif %}
+            {%- else -%}
+              {%- assign placeholder_slide = forloop.index | modulo: 2 -%}
+              {%- if placeholder_slide == 1 -%}
+                {{ 'hero-apparel-2' | placeholder_svg_tag: 'placeholder-svg' }}
+              {%- else -%}
+                {{ 'hero-apparel-1' | placeholder_svg_tag: 'placeholder-svg' }}
+              {%- endif -%}
+            {%- endif -%}
+          </div>
+          <div class="slideshow__text-wrapper banner__content banner__content--{{ block.settings.box_align }} page-width{% if block.settings.show_text_box == false %} banner--desktop-transparent{% endif %}">
+            <div class="slideshow__text banner__box content-container content-container--full-width-mobile color-{{ block.settings.color_scheme }} slideshow__text--{{ block.settings.text_alignment }} slideshow__text-mobile--{{ block.settings.text_alignment_mobile }}">
+              {%- if block.settings.heading != blank -%}
+                {% if block.settings.heading_size == 'h1' %}
+                  <h1 class="banner__heading inline-richtext">{{ block.settings.heading }}</h1>
+                {% else %}
+                  <h2 class="banner__heading inline-richtext">{{ block.settings.heading }}</h2>
+                {% endif %}
+              {%- endif -%}
+              {%- if block.settings.subheading != blank -%}
+                <div class="banner__text rte">
+                  {{ block.settings.subheading }}
+                </div>
+              {%- endif -%}
+              {%- if block.settings.button_label != blank or block.settings.sbutton_label != blank -%}
+                <div class="banner__buttons">
+                  <a
+                    {% if block.settings.link %}
+                      href="{{ block.settings.link }}"
+                    {% else %}
+                      role="link" aria-disabled="true"
+                    {% endif %}
+                    class="button button--primary"
+                  >
+                    {{- block.settings.button_label | escape -}}
+                  </a>
+                  <a
+                    {% if block.settings.slink %}
+                      href="{{ block.settings.slink }}"
+                    {% else %}
+                      role="link" aria-disabled="true"
+                    {% endif %}
+                    class="button button--secondary"
+                  >
+                    {{- block.settings.sbutton_label | escape -}}
+                  </a>
+                </div>
+              {%- endif -%}
+            </div>
+          </div>
+          <style>
+            {% if block.settings.opacity_effect == 'fullscreen' %}
+            #Slide-{{ section.id }}-{{ forloop.index }} .banner__media::after {
+              opacity: {{ block.settings.image_overlay_opacity | divided_by: 100.0 }};
+            }
+            {% endif %}
+            @media (max-width: 749px){
+              {% if block.settings.mobile_overlay == true %}
+               #Slide-{{ section.id }}-{{ forloop.index }} .banner__media::after {
+                opacity: 1;
+                background: #0009;
+              }
+              {% else %}
+               #Slide-{{ section.id }}-{{ forloop.index }} .banner__media::after {
+                opacity: 0;
+              }
+              {% endif %}
+            }
+            {% if block.settings.shadow_color == true %}
+              #Slide-{{ section.id }}-{{ forloop.index }} h1,
+              #Slide-{{ section.id }}-{{ forloop.index }} h2,
+              #Slide-{{ section.id }}-{{ forloop.index }} p {
+                -webkit-text-stroke: 2px {{ block.settings.text_shadow_color }};
+                text-shadow: 0 0 2px {{ block.settings.text_shadow_color }}, 0 0 10px {{ block.settings.text_shadow_color }}, 0 0 2px {{ block.settings.text_shadow_color }}, 0 0 5px {{ block.settings.text_shadow_color }};
+              }
+            {%endif %}
+          </style>
+        </div>
+        </div>
+      {%- endfor -%}
     </div>
-  {%- endif -%}
-</slideshow-component>
+    </div>
+    {%- if section.settings.show_slider_nav == true -%}
+      <div class="swiper-button-prev">{{- 'icon-caret.svg' | inline_asset_content -}}</div>
+      <div class="swiper-button-next">{{- 'icon-caret.svg' | inline_asset_content -}}</div>
+    {% endif %}
+    {%- if section.settings.slider_dots == true -%}<div class="swiper-pagination"></div>{% endif %}
+</div>
 
-{%- if request.design_mode -%}
-  <script src="{{ 'theme-editor.js' | asset_url }}" defer="defer"></script>
-{%- endif -%}
+<script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+<script>
+  new Swiper('.section-{{ section.id }} .slideshow', {
+        loop: true,
+        slidesPerView: 1,
+        autoplay: {{section.settings.auto_rotate}},{%- if section.settings.auto_rotate == true -%}
+        speed: 700,
+        autoplay: {
+          delay: {{ section.settings.change_slides_speed }}000
+        },{% endif %}
+        {%- if section.settings.show_slider_nav == true -%}
+          navigation: {
+            nextEl: '.section-{{ section.id }} .swiper-button-next',
+            prevEl: '.section-{{ section.id }} .swiper-button-prev',
+        },{% endif %}
+        {%- if section.settings.slider_dots == true -%} pagination: {
+            el: '.section-{{ section.id }} .swiper-pagination',
+            clickable: true
+        }{% endif %}
+    });
+</script>
 
 {% schema %}
 {
@@ -311,6 +234,18 @@
       "label": "t:sections.slideshow.settings.slide_height.label"
     },
     {
+      "type": "checkbox",
+      "id": "show_slider_nav",
+      "label": "Show slider navigation",
+      "default": false
+    },
+    {
+      "type": "checkbox",
+      "id": "slider_dots",
+      "label": "Show slider navigation dots",
+      "default": true
+    },
+    {
       "type": "select",
       "id": "slider_visual",
       "options": [
@@ -328,7 +263,8 @@
         }
       ],
       "default": "counter",
-      "label": "t:sections.slideshow.settings.slider_visual.label"
+      "label": "slider navigation style",
+      "visible_if": "{{ section.settings.show_slider_nav == true }}"
     },
     {
       "type": "checkbox",
@@ -344,23 +280,8 @@
       "step": 2,
       "unit": "s",
       "label": "t:sections.slideshow.settings.change_slides_speed.label",
-      "default": 5
-    },
-    {
-      "type": "select",
-      "id": "image_behavior",
-      "options": [
-        {
-          "value": "none",
-          "label": "t:sections.all.animation.image_behavior.options__1.label"
-        },
-        {
-          "value": "ambient",
-          "label": "t:sections.all.animation.image_behavior.options__2.label"
-        }
-      ],
-      "default": "none",
-      "label": "t:sections.all.animation.image_behavior.label"
+      "default": 5,
+      "visible_if": "{{ section.settings.auto_rotate == true }}"
     },
     {
       "type": "header",
@@ -391,23 +312,116 @@
       "limit": 5,
       "settings": [
         {
+          "type": "select",
+          "id": "vid_image",
+          "options": [
+            {
+              "value": "image",
+              "label": "Image"
+            },
+            {
+              "value": "video",
+              "label": "Video"
+            }
+          ],
+          "default": "image",
+          "label": "Select an image or video for background",
+          "info": "Adding video will replace background with an image"
+        },
+        {
           "type": "image_picker",
-          "id": "image",
-          "label": "t:sections.slideshow.blocks.slide.settings.image.label"
+          "id": "main_bg",
+          "label": "Background image",
+          "visible_if": "{{ block.settings.vid_image == 'image' }}"
+        },
+        {
+          "type": "image_picker",
+          "id": "main_mobile_bg",
+          "label": "Mobile Background image",
+          "visible_if": "{{ block.settings.vid_image == 'image' }}",
+          "info": "If this image is not added, the desktop image will be used automatically."
+        },
+        {
+          "type": "checkbox",
+          "id": "enable_video_looping",
+          "label": "Video playing in the loop",
+          "default": false,
+          "visible_if": "{{ block.settings.vid_image == 'video' }}"
+        },
+        {
+          "type": "video",
+          "id": "main_video_bg",
+          "label": "Video",
+          "visible_if": "{{ block.settings.vid_image == 'video' }}"
+        },
+        {
+          "type": "video",
+          "id": "mob_video_bg",
+          "label": "Responsive Video",
+          "visible_if": "{{ block.settings.vid_image == 'video' }}",
+          "info": "If this video is not added, the desktop video will be used automatically."
+        },
+        {
+          "type": "select",
+          "id": "opacity_effect",
+          "options": [
+            {
+              "value": "none",
+              "label": "None"
+            },
+            {
+              "value": "ltr",
+              "label": "Left to Right"
+            },
+            {
+              "value": "rtl",
+              "label": "Right to Left"
+            },
+            {
+              "value": "fullscreen",
+              "label": "All over banner"
+            }
+          ],
+          "default": "none",
+          "label": "Banner overlay effect",
+          "info": "Select an effect to add an overlay on the banner image for desktop screens."
         },
         {
           "type": "range",
           "id": "image_overlay_opacity",
           "min": 0,
-          "max": 100,
-          "step": 10,
+          "max": 90,
+          "step": 5,
           "unit": "%",
           "label": "t:sections.slideshow.blocks.slide.settings.image_overlay_opacity.label",
-          "default": 0
+          "default": 0,
+          "visible_if": "{{ block.settings.opacity_effect == 'fullscreen' }}"
+        },
+        {
+          "type": "checkbox",
+          "id": "mobile_overlay",
+          "label": "Show overlay over banner in Mobile",
+          "default": false
         },
         {
           "type": "header",
           "content": "t:sections.slideshow.blocks.slide.settings.header_text.content"
+        },
+        {
+          "type": "select",
+          "id": "heading_size",
+          "options": [
+            {
+              "value": "h1",
+              "label": "h1"
+            },
+            {
+              "value": "h2",
+              "label": "h2"
+            }
+          ],
+          "default": "h2",
+          "label": "t:sections.all.heading_size.label"
         },
         {
           "type": "inline_richtext",
@@ -416,48 +430,38 @@
           "label": "t:sections.slideshow.blocks.slide.settings.heading.label"
         },
         {
-          "type": "select",
-          "id": "heading_size",
-          "options": [
-            {
-              "value": "h2",
-              "label": "t:sections.all.heading_size.options__1.label"
-            },
-            {
-              "value": "h1",
-              "label": "t:sections.all.heading_size.options__2.label"
-            },
-            {
-              "value": "h0",
-              "label": "t:sections.all.heading_size.options__3.label"
-            },
-            {
-              "value": "hxl",
-              "label": "t:sections.all.heading_size.options__4.label"
-            },
-            {
-              "value": "hxxl",
-              "label": "t:sections.all.heading_size.options__5.label"
-            }
-          ],
-          "default": "h1",
-          "label": "t:sections.all.heading_size.label"
-        },
-        {
-          "type": "inline_richtext",
+          "type": "richtext",
           "id": "subheading",
           "default": "t:sections.slideshow.blocks.slide.settings.subheading.default",
           "label": "t:sections.slideshow.blocks.slide.settings.subheading.label"
         },
         {
+          "type": "color_scheme",
+          "id": "color_scheme",
+          "label": "t:sections.all.colors.label",
+          "default": "scheme-1"
+        },
+        {
+          "type": "checkbox",
+          "id": "shadow_color",
+          "label": "Text Shadow Color Apply",
+          "default": false
+        },
+        {
+          "type": "color",
+          "id": "text_shadow_color",
+          "label": "Text Shadow Color",
+          "visible_if": "{{ block.settings.shadow_color == true }}"
+        },
+        {
           "type": "header",
-          "content": "t:sections.slideshow.blocks.slide.settings.header_button.content"
-        },        
+          "content": "Primary Button"
+        },
         {
           "type": "text",
           "id": "button_label",
           "default": "t:sections.slideshow.blocks.slide.settings.button_label.default",
-          "label": "t:sections.slideshow.blocks.slide.settings.button_label.label", 
+          "label": "t:sections.slideshow.blocks.slide.settings.button_label.label",
           "info": "t:sections.slideshow.blocks.slide.settings.button_label.info"
         },
         {
@@ -466,15 +470,24 @@
           "label": "t:sections.slideshow.blocks.slide.settings.link.label"
         },
         {
-          "type": "checkbox",
-          "id": "button_style_secondary",
-          "label": "t:sections.slideshow.blocks.slide.settings.secondary_style.label",
-          "default": false
+          "type": "header",
+          "content": "Secondary Button"
+        },
+        {
+          "type": "text",
+          "id": "sbutton_label",
+          "label": "t:sections.slideshow.blocks.slide.settings.button_label.label",
+          "info": "t:sections.slideshow.blocks.slide.settings.button_label.info"
+        },
+        {
+          "type": "url",
+          "id": "slink",
+          "label": "t:sections.slideshow.blocks.slide.settings.link.label"
         },
         {
           "type": "header",
           "content": "t:sections.slideshow.blocks.slide.settings.header_layout.content"
-        },         
+        },
         {
           "type": "checkbox",
           "id": "show_text_box",
@@ -564,12 +577,6 @@
           ],
           "default": "center",
           "label": "t:sections.slideshow.blocks.slide.settings.text_alignment_mobile.label"
-        },        
-        {
-          "type": "color_scheme",
-          "id": "color_scheme",
-          "label": "t:sections.all.colors.label",
-          "default": "scheme-1"
         }
       ]
     }

--- a/snippets/ctm-media.liquid
+++ b/snippets/ctm-media.liquid
@@ -1,0 +1,71 @@
+{% assign class = class | default: settings.main_video_bg %}
+{% assign video = video | default: settings.main_video_bg %}
+{% assign mob_video = mob_video | default: settings.mob_video_bg %}
+{% assign image = image | default: settings.main_bg %}
+{% assign mob_image = mob_image | default: settings.main_mobile_bg %}
+{% assign enable_looping = enable_looping | default: settings.enable_video_looping %}
+{% assign heading = heading | default: '' %}
+{% assign loading = loading | default: 'lazy' %}
+{% assign fetchpriority = fetchpriority | default: 'auto' %}
+
+
+<div class="{{ class }}">
+  {% if video != blank %}
+    {% assign desktop_video_class = 'max-w-full h-auto' %}
+    {% if mob_video != blank %}
+      {% assign desktop_video_class = 'desktop_only max-w-full h-auto' %}
+    {% endif %}
+    {{
+      video
+      | video_tag:
+        image_size: '1100x',
+        class: desktop_video_class,
+        loop: enable_looping,
+        controls: false,
+        autoplay: true,
+        muted: true
+    }}
+
+    {% if mob_video != blank %}
+      {{
+        mob_video
+        | video_tag:
+          image_size: '1100x',
+          class: 'mobile_only max-w-full h-auto',
+          loop: enable_looping,
+          controls: false,
+          autoplay: true,
+          muted: true
+      }}
+    {% endif %}
+    
+  {% elsif image != blank %}
+    
+    {% assign image_class = '' %}
+    {% if mob_image != blank %}
+      {% assign image_class = image_class | append: 'desktop_only ' %}
+    {% endif %}
+    {% assign image_class = image_class | append: 'max-w-full h-auto' %}
+    {{
+      image
+      | image_url: width: image.width
+      | image_tag: alt: heading, loading: loading,
+        fetchpriority: fetchpriority, class: image_class, width: image.width, height: image.height
+    }}
+    
+    {% if mob_image != blank %}
+      {{
+        mob_image
+        | image_url: width: mob_image.width
+        | image_tag:
+          alt: heading,
+          loading: loading,
+          fetchpriority: fetchpriority,
+          class: 'mobile_only max-w-full h-auto',
+          width: mob_image.width,
+          height: mob_image.height
+      }}
+    {% endif %}
+    
+  {% endif %}
+</div>

--- a/templates/index.json
+++ b/templates/index.json
@@ -1,61 +1,87 @@
+/*
+ * ------------------------------------------------------------
+ * IMPORTANT: The contents of this file are auto-generated.
+ *
+ * This file may be updated by the Shopify admin theme editor
+ * or related systems. Please exercise caution as any changes
+ * made to this file may be overwritten.
+ * ------------------------------------------------------------
+ */
 {
   "sections": {
-    "image_banner": {
-      "type": "image-banner",
+    "slideshow_XW7KFG": {
+      "type": "slideshow",
       "blocks": {
-        "heading": {
-          "type": "heading",
+        "slide_VtFTe7": {
+          "type": "slide",
           "settings": {
-            "heading": "Browse our latest products",
-            "heading_size": "h0"
+            "image_overlay_opacity": 0,
+            "heading": "Image slide",
+            "heading_size": "h1",
+            "subheading": "Tell your brand's story through images",
+            "button_label": "Button label",
+            "link": "",
+            "sbutton_label": "Button label",
+            "slink": "",
+            "show_text_box": true,
+            "box_align": "middle-center",
+            "text_alignment": "center",
+            "text_alignment_mobile": "center",
+            "color_scheme": ""
           }
         },
-        "button": {
-          "type": "buttons",
+        "slide_77Ar3U": {
+          "type": "slide",
           "settings": {
-            "button_label_1": "Shop all",
-            "button_link_1": "shopify://collections/all",
-            "button_style_secondary_1": true,
-            "button_label_2": "",
-            "button_link_2": "",
-            "button_style_secondary_2": false
+            "image_overlay_opacity": 0,
+            "heading": "Image slide",
+            "heading_size": "h1",
+            "subheading": "Tell your brand's story through images",
+            "button_label": "Button label",
+            "link": "",
+            "sbutton_label": "Button label",
+            "slink": "",
+            "show_text_box": true,
+            "box_align": "middle-center",
+            "text_alignment": "center",
+            "text_alignment_mobile": "center",
+            "color_scheme": ""
           }
         }
       },
       "block_order": [
-        "heading",
-        "button"
+        "slide_VtFTe7",
+        "slide_77Ar3U"
       ],
+      "name": "t:sections.slideshow.presets.name",
       "settings": {
-        "image_overlay_opacity": 40,
-        "image_height": "large",
-        "desktop_content_position": "bottom-center",
-        "show_text_box": false,
+        "layout": "full_bleed",
+        "slide_height": "medium",
+        "show_slider_nav": false,
+        "slider_visual": "counter",
+        "auto_rotate": false,
+        "change_slides_speed": 5,
         "image_behavior": "none",
-        "desktop_content_alignment": "center",
-        "color_scheme": "scheme-3",
-        "mobile_content_alignment": "center",
-        "stack_images_on_mobile": false,
-        "show_text_below": false
+        "show_text_below": true,
+        "accessibility_info": "Slideshow about our brand"
       }
     },
     "featured_collection": {
       "type": "featured-collection",
       "settings": {
+        "collection": "all",
+        "products_to_show": 8,
         "title": "Featured products",
         "heading_size": "h2",
         "description": "",
         "show_description": false,
         "description_style": "body",
-        "collection": "all",
-        "products_to_show": 8,
         "columns_desktop": 4,
-        "color_scheme": "scheme-1",
+        "enable_desktop_slider": false,
         "full_width": false,
         "show_view_all": true,
         "view_all_style": "solid",
-        "enable_desktop_slider": false,
-        "swipe_on_mobile": false,
+        "color_scheme": "scheme-1",
         "image_ratio": "adapt",
         "image_shape": "default",
         "show_secondary_image": true,
@@ -63,13 +89,14 @@
         "show_rating": false,
         "quick_add": "none",
         "columns_mobile": "2",
+        "swipe_on_mobile": false,
         "padding_top": 44,
         "padding_bottom": 36
       }
     }
   },
   "order": [
-    "image_banner",
+    "slideshow_XW7KFG",
     "featured_collection"
   ]
 }


### PR DESCRIPTION
We have modified the slideshow code: The Swiper slider has replaced the default slider, since the default slider had limitations and could not be reused in other themes.
Theme animations have been removed as they conflicted with the slider.

**How to use:**
1. Copy the code from sections/slideshow.liquid and paste it into your theme.
2. Apply the same for all CSS files included in that section.
3. The Swiper slider CSS and JS CDN links are already added in the section code.
4. If you have already included these files in theme.liquid, you can safely remove them from the section file.
